### PR TITLE
Update layout.ejs

### DIFF
--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -15,15 +15,6 @@
 </head>
 
 <body>
-  <!-- <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js", type="text/javascript"></script>-->
-  <script src="./bower_components/jquery/dist/jquery.min.js"></script>
-  <script src="./bower_components/is_js/is.min.js"></script>
-  <script src="./bower_components/masonry/dist/masonry.pkgd.js"></script>
-  <script src="./bower_components/accounting/accounting.min.js"></script>
-  <script src="./bower_components/datejs/build/date.js"></script>
-  <script src="./bower_components/simple-statistics/src/simple_statistics.js"></script>
-  <script src="./javascripts/index.js"></script>
-
   <div class="navbar-wrapper">
     <header class="header" role="navigation" >
       <div class="wrap classpass-wrapper">
@@ -160,7 +151,16 @@
       </div>
     </div>
   </footer>
+  <!-- Javascripts -->
   
+    <!-- <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js", type="text/javascript"></script>-->
+  <script src="./bower_components/jquery/dist/jquery.min.js"></script>
+  <script src="./bower_components/is_js/is.min.js"></script>
+  <script src="./bower_components/masonry/dist/masonry.pkgd.js"></script>
+  <script src="./bower_components/accounting/accounting.min.js"></script>
+  <script src="./bower_components/datejs/build/date.js"></script>
+  <script src="./bower_components/simple-statistics/src/simple_statistics.js"></script>
+  <script src="./javascripts/index.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Mozilla backed best practice-- move scripts to end of the document for performant pages.

Offsets script loading until _after_ the DOM has loaded.
https://developer.mozilla.org/en-US/Learn/Getting_started_with_the_web/JavaScript_basics
